### PR TITLE
Do not destroy previous Polyline options

### DIFF
--- a/L.Polyline.measuredDistance.js
+++ b/L.Polyline.measuredDistance.js
@@ -6,7 +6,7 @@
 
 L.Polyline.prototype.measuredDistance = function (options) {
   // Default options
-  this.defaultOptions = L.extend(this.defaultOptions, {
+  this.defaultOptions = L.extend(this.defaultOptions || {}, {
     metric: true
   });
   // Extend options

--- a/L.Polyline.measuredDistance.js
+++ b/L.Polyline.measuredDistance.js
@@ -6,11 +6,11 @@
 
 L.Polyline.prototype.measuredDistance = function (options) {
   // Default options
-  this.defaults = {
+  this.defaultOptions = L.extend(this.defaultOptions, {
     metric: true
-  };
+  });
   // Extend options
-  this.options = L.extend(this.defaults, options);
+  this.options = L.extend(this.defaultOptions, this.options, options);
 
   var distance = 0,  coords = null, coordsArray = this._latlngs;
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "leaflet-polyline-measured-distance",
+    "version": "1.0.0",
+    "description": "Leaflet.PolylineMeasuredDistance is a plugin that displays a polyline distance",
+    "main": "L.Polyline.measuredDistance.js",
+    "scripts": {
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/EASYMOUNTAIN/Leaflet.PolylineMeasuredDistance.git"
+    },
+    "author": "danimt",
+    "contributors": ["easymountain"],
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/EASYMOUNTAIN/Leaflet.PolylineMeasuredDistance/issues"
+    },
+    "homepage": "https://github.com/EASYMOUNTAIN/Leaflet.PolylineMeasuredDistance#readme",
+    "devDependencies": {
+    },
+    "dependencies": {}
+  }


### PR DESCRIPTION
The previous code erased all other Polyline options.
Better use defaultOptions instead of defaults too.